### PR TITLE
change templating classes to pydantic models

### DIFF
--- a/src/app/transformation/abstract_model.py
+++ b/src/app/transformation/abstract_model.py
@@ -2,75 +2,43 @@ import json
 from enum import Enum
 from typing import List
 
+from pydantic import BaseModel
+
 
 ProgrammingStatement = str
 DependeeReference = str
 
 
-class Serializable:
-    def to_json(self):
-        return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=4)
-
-
-class MetaInformation:
+class MetaInformation(BaseModel):
     language: str
     title: str
     version: str
 
-    def __init__(self, language: str, title: str, version: str):
-        self.language = language
-        self.title = title
-        self.version = version
 
-
-class Dependee:
+class Dependee(BaseModel):
     generated_reference: DependeeReference
     initializer: ProgrammingStatement
 
-    def __init__(self, generated_reference: DependeeReference, initializer: ProgrammingStatement):
-        self.generated_reference = generated_reference
-        self.initializer = initializer
 
-
-class Setup:
+class Setup(BaseModel):
     independent: List[str]
     dependees: List[Dependee]
 
-    def __init__(self, independent: List[str], dependees: List[Dependee]):
-        self.independent = independent
-        self.dependees = dependees
-
 
 class ParameterType(Enum):
-    STRING = 0
-    NUMBER = 1
+    STRING = "string"
+    NUMBER = "number"
 
 
-class NamedParameter:
+class NamedParameter(BaseModel):
     abstract_name: str
     generated_name: str
     type: ParameterType
     description: str
 
-    def __init__(self, abstract_name: str, generated_name: str, type: ParameterType, description: str):
-        self.abstract_name = abstract_name
-        self.generated_name = generated_name
-        self.type = type
-        self.description = description
 
-
-class Action:
+class Action(BaseModel):
     abstract_name: str
     generated_name: str
     generated_actor: DependeeReference
     named_parameters: List[NamedParameter]
-
-    def __init__(self,
-                 abstract_name: str,
-                 generated_name: str,
-                 generated_actor: DependeeReference,
-                 named_parameters: List[NamedParameter]):
-        self.abstract_name = abstract_name
-        self.generated_name = generated_name
-        self.generated_actor = generated_actor
-        self.named_parameters = named_parameters

--- a/src/app/transformation/instance_model.py
+++ b/src/app/transformation/instance_model.py
@@ -1,25 +1,17 @@
 from typing import List
 
+from pydantic import BaseModel
+
 from app.schemas.actions import action
 from app.transformation import abstract_model
 from app.transformation import template
 
 
-class InstanceModel:
+class InstanceModel(BaseModel):
     meta: abstract_model.MetaInformation
     init: List[List[abstract_model.ProgrammingStatement]]
     setup: abstract_model.Setup
     actions: List[template.Action]
-
-    def __init__(self,
-                 meta: abstract_model.MetaInformation,
-                 init: List[List[abstract_model.ProgrammingStatement]],
-                 setup: abstract_model.Setup,
-                 actions: List[template.Action]):
-        self.meta = meta
-        self.init = init
-        self.setup = setup
-        self.actions = actions
 
 
 def create_instance_model(temp: template.Template, abstract_actions: List[action.Action]):
@@ -28,4 +20,4 @@ def create_instance_model(temp: template.Template, abstract_actions: List[action
         instance_action = temp.instantiate_action(abstract_action)
         instance_actions.append(instance_action)
 
-    return InstanceModel(temp.meta, temp.init, temp.setup, instance_actions)
+    return InstanceModel(meta=temp.meta, init=temp.init, setup=temp.setup, actions=instance_actions)


### PR DESCRIPTION
Removes the need for declaring initializers on our own. Will also make later integration with other FastAPI components easier.