### PR TITLE
Add generic error handling for unhandled exception

### DIFF
--- a/src/app/api/api_v1/api.py
+++ b/src/app/api/api_v1/api.py
@@ -1,8 +1,8 @@
-from fastapi import APIRouter
 from app.api.api_v1.endpoints import (test, robot, robot_type, welding_configuration, welding_point,
                                       generation_template, code_generation)
+from app.api.generic_exception_handler import APIRouterWithGenericExceptionHandler
 
-api_router = APIRouter()
+api_router = APIRouterWithGenericExceptionHandler()
 api_router.include_router(robot_type.router, prefix="/robottype", tags=["RobotType"])
 api_router.include_router(robot.router, prefix="/robot", tags=["Robot"])
 api_router.include_router(welding_configuration.router, prefix="/weldingconfiguration", tags=["WeldingConfiguration"])

--- a/src/app/api/api_v1/endpoints/code_generation.py
+++ b/src/app/api/api_v1/endpoints/code_generation.py
@@ -1,16 +1,17 @@
 from typing import Any
-from fastapi import APIRouter, HTTPException
+from fastapi import HTTPException
 from fastapi.params import Depends
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api import deps
+from app.api.generic_exception_handler import APIRouterWithGenericExceptionHandler
 from app.crud.crud_generation_template import generation_template
 from app.crud.crud_welding_configuration import welding_configuration
 from app.codegen.code_generator import CodeGenerator
 
 
-router = APIRouter()
+router = APIRouterWithGenericExceptionHandler()
 
 
 class RequestBodyGenerate(BaseModel):

--- a/src/app/api/api_v1/endpoints/generation_template.py
+++ b/src/app/api/api_v1/endpoints/generation_template.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import Depends, HTTPException
 from app.api import deps
+from app.api.generic_exception_handler import APIRouterWithGenericExceptionHandler
 from app.crud.crud_generation_template import *
 from app.schemas.generation_template import *
 
 
-router = APIRouter()
+router = APIRouterWithGenericExceptionHandler()
 
 
 @router.get("/", response_model=List[GenerationTemplate])

--- a/src/app/api/api_v1/endpoints/robot.py
+++ b/src/app/api/api_v1/endpoints/robot.py
@@ -1,10 +1,12 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import Depends, HTTPException
+
 from app.api import deps
+from app.api.generic_exception_handler import APIRouterWithGenericExceptionHandler
 from app.crud.crud_robot import *
 from app.schemas.robot import *
 
 
-router = APIRouter()
+router = APIRouterWithGenericExceptionHandler()
 
 
 @router.get("/", response_model=List[Robot])

--- a/src/app/api/api_v1/endpoints/robot_type.py
+++ b/src/app/api/api_v1/endpoints/robot_type.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import Depends, HTTPException
 from app.api import deps
+from app.api.generic_exception_handler import APIRouterWithGenericExceptionHandler
 from app.crud.crud_robot_type import *
 from app.schemas.robot_type import *
 
 
-router = APIRouter()
+router = APIRouterWithGenericExceptionHandler()
 
 
 @router.get("/", response_model=List[RobotType])

--- a/src/app/api/api_v1/endpoints/test.py
+++ b/src/app/api/api_v1/endpoints/test.py
@@ -1,9 +1,11 @@
-from fastapi import APIRouter, Body, HTTPException, Depends
+from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.api import deps
+from app.api.generic_exception_handler import APIRouterWithGenericExceptionHandler
 
 
-router = APIRouter()
+router = APIRouterWithGenericExceptionHandler()
 
 
 @router.get("/test/{id}")

--- a/src/app/api/api_v1/endpoints/test/generation_template_test.py
+++ b/src/app/api/api_v1/endpoints/test/generation_template_test.py
@@ -86,19 +86,19 @@ class GenerationTemplateTest(unittest.TestCase):
     def test_post_wrong_content_type(self):
         response = self.client.post("/api/v1/generationtemplate/",
                                     b'{"name": "My Template", "content": { "value": "{{fill}}" }}')
-        self.assertEqual(422, response.status_code)
+        self.assertEqual(400, response.status_code)
 
     def test_post_wrong_name_type(self):
         response = self.client.post("/api/v1/generationtemplate/",
                                     b'{"name": [5], "content": ""}')
-        self.assertEqual(422, response.status_code)
+        self.assertEqual(400, response.status_code)
 
     def test_post_missing_content(self):
         response = self.client.post("/api/v1/generationtemplate/",
                                     b'{"name": [5]}')
-        self.assertEqual(422, response.status_code)
+        self.assertEqual(400, response.status_code)
 
     def test_post_missing_name(self):
         response = self.client.post("/api/v1/generationtemplate/",
                                     b'{"content": ""}')
-        self.assertEqual(422, response.status_code)
+        self.assertEqual(400, response.status_code)

--- a/src/app/api/api_v1/endpoints/welding_configuration.py
+++ b/src/app/api/api_v1/endpoints/welding_configuration.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import Depends, HTTPException
 from app.api import deps
+from app.api.generic_exception_handler import APIRouterWithGenericExceptionHandler
 from app.crud.crud_welding_configuration import *
 from app.schemas.welding_configuration import *
 
 
-router = APIRouter()
+router = APIRouterWithGenericExceptionHandler()
 
 
 @router.get("/", response_model=List[WeldingConfiguration])

--- a/src/app/api/api_v1/endpoints/welding_point.py
+++ b/src/app/api/api_v1/endpoints/welding_point.py
@@ -1,11 +1,12 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import Depends, HTTPException
 from app.api import deps
+from app.api.generic_exception_handler import APIRouterWithGenericExceptionHandler
 from app.crud.crud_welding_point import *
 from app.crud.crud_welding_configuration import *
 from app.schemas.welding_point import *
 
 
-router = APIRouter()
+router = APIRouterWithGenericExceptionHandler()
 
 
 @router.get("/", response_model=List[WeldingPoint])

--- a/src/app/api/generic_exception_handler.py
+++ b/src/app/api/generic_exception_handler.py
@@ -1,0 +1,34 @@
+from typing import Callable
+
+from fastapi import HTTPException, Request, Response
+from fastapi.routing import APIRoute, APIRouter
+
+
+class APIRouterWithGenericExceptionHandler(APIRouter):
+    """
+    The custom route_class gets overridden everytime a new APIRouter is added. This wrapper class adds the
+    generic exception handler route class by default. Needs to be used for all APIRouter as replacement in the
+    application to work.
+    """
+    def __init__(self):
+        super().__init__(route_class=GenericExceptionHandler)
+
+
+class GenericExceptionHandler(APIRoute):
+    """
+    Custom route to catch unhandled exceptions to convert them into HTTPExceptions. The original exception message is
+    added to the detail of the HTTPException. If an HTTPException is already thrown, it is passed on without
+    intervention. HTTPExceptions are handled by the default exception handler of FastAPI, if not changed.
+    """
+    def get_route_handler(self) -> Callable:
+        original_route_handler = super().get_route_handler()
+
+        async def custom_route_handler(request: Request) -> Response:
+            try:
+                return await original_route_handler(request)
+            except HTTPException as ex:
+                raise ex
+            except Exception as ex:
+                raise HTTPException(status_code=400, detail=repr(ex))
+
+        return custom_route_handler


### PR DESCRIPTION
Adds a generic error handler if an error is not catched by the backend. Some minor import reformatting as well.
* Prevents useless responses like `Internal server error` while we are still in the process of developing. Should be useful for the frontend as well, when integrating the backend
* We still recognize, which exceptions are thrown generically to handle them properly in the long term. See example at the end
* If exception is already `HTTPException` then it is passed on without change

Had to use a "workaround" with a custom `APIRouter`. Explanation is in the code. Sorry for the verbose naming, but had no other idea how to name it.
```
{
  "detail": "IntegrityError('(sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) <class \\'asyncpg.exceptions.ForeignKeyViolationError\\'>: insert or update on table \"weldingpoint\" violates foreign key constraint \"weldingpoint_welding_configuration_id_fkey\"\\nDETAIL:  Key (welding_configuration_id)=(1) is not present in table \"weldingconfiguration\".')"
}
```