### PR TITLE
Enable cascading deletes for welding configuration

### DIFF
--- a/src/app/models/welding_configuration.py
+++ b/src/app/models/welding_configuration.py
@@ -10,4 +10,5 @@ class WeldingConfiguration(Base):
     description = Column(String)
     created_at = Column(DateTime, server_default=func.now())
     modified_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
-    welding_points = relationship("WeldingPoint", back_populates="welding_configuration", lazy='subquery')
+    welding_points = relationship("WeldingPoint", back_populates="welding_configuration", lazy='subquery',
+                                  cascade="all, delete")


### PR DESCRIPTION
This enables cascading deletes for welding configuration. So if we delete a welding configuration, we also delete all attached welding points as well. But deleting a welding point still just deletes the welding point and not the configuration.

I did not enable this for robot types and robots, since this is a bit more tricky and should only be done with warning and some user info before doing. Deleting a robot type and also deleting the robots can easily violate foreign key constraints, as robots are used for welding points. To be safe, deleting robot types should actually be forbidden for the user in the current state. To fix all these problems, we probably should(tm) switch to mark for deletion / soft delete.