### PR TITLE
docker: use conda instead of pip for Apple Silicon compatibility

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,13 +1,14 @@
-FROM python:slim
-
+FROM continuumio/anaconda3:latest
 ENV PYTHONPATH "${PYTHONPATH}:/"
 ENV PORT=8000
 
-RUN pip install --upgrade pip
+RUN conda update conda
+# Add community repository, since e.g. FastAPI is not available in the official repos
+RUN conda config --add channels conda-forge
+RUN conda config --set channel_priority strict
 
 COPY requirements.txt /app/
-RUN pip install -r /app/requirements.txt
-
+RUN conda create --name sqe-backend --file /app/requirements.txt
 COPY ./app /app
 
-CMD ["uvicorn", "--host", "0.0.0.0", "app.main:app"]
+CMD ["conda", "run", "-n", "sqe-backend", "uvicorn", "--host", "0.0.0.0", "app.main:app"]


### PR DESCRIPTION
Currently, the dockerfile does not build on Apple M1 (and probably M2) SoCs, because of the async `psycopg2` package. It seems that something is not correctly configured for this package for arm, but don't know the real reason for this problem. From a GitHub issue in the official package repo, there is the workaround to use conda instead for now, as this works. @dittmanndennis could confirm that it works for him now with conda instead of pip.

Should not make a difference for us, and hopefully all future packages we use are also available for conda. 

