### PR TITLE
docker: make arm64 and Apple Silicon compatible

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:slim
 
-ENV PYTHONPATH "${PYTHONPATH}:/"
-ENV PORT=8000
-
 # Build dependencies for psycopg2
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,6 +3,11 @@ FROM python:slim
 ENV PYTHONPATH "${PYTHONPATH}:/"
 ENV PORT=8000
 
+# Build dependencies for psycopg2
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libpq5 \
+    libpq-dev
 RUN pip install --upgrade pip
 
 COPY requirements.txt /app/

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,7 +7,7 @@ alembic
 asyncpg
 greenlet
 bson
-psycopg2-binary
+psycopg2
 Jinja2
 pytest
 testing.postgresql


### PR DESCRIPTION
We build `psycopg2` now manually, sadly even for amd64. But with this way we are compatible with arm64 and therefor Apple Silicon. `psycopg2` is not yet available as arm64 package in pip, only in conda. But conda is missing another package in their repos.

Tested with my Raspberry Pi and @dittmanndennis tested on a M1 mac.