### PR TITLE
Add CORSMiddleware to handle CORS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
         environment:
             DATABASE_URL_ASYNC: "postgresql+asyncpg://postgres:awesomepw@sqe_database:5432"
             DATABASE_URL_SYNC: "postgresql://postgres:awesomepw@sqe_database:5432"
-
+            CORS_ORIGINS: "http://localhost:3000,http://127.0.0.1:3000"
+            
     sqe_database:
         container_name: sqe_database
         image: postgres:14.2-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,4 +40,3 @@ services:
 volumes:
     postgres:
     pgadmin:
-

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -1,4 +1,6 @@
 import os
+from typing import List
+
 from pydantic import AnyHttpUrl, BaseSettings
 
 
@@ -10,6 +12,7 @@ class Settings(BaseSettings):
     # ToDo: store and access secrets properly
     DATABASE_URL_ASYNC: str = os.getenv("DATABASE_URL_ASYNC", f"postgresql+asyncpg://postgres:awesomepw@localhost:5432")
     DATABASE_URL_SYNC: str = os.getenv("DATABASE_URL_SYNC", "postgresql://postgres:awesomepw@localhost:5432")
+    CORS_ORIGINS: List[str] = os.getenv("CORS_ORIGINS", "http://localhost:3000,http://127.0.0.1:3000").split(",")
 
 
 settings = Settings()

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -14,5 +14,12 @@ class Settings(BaseSettings):
     DATABASE_URL_SYNC: str = os.getenv("DATABASE_URL_SYNC", "postgresql://postgres:awesomepw@localhost:5432")
     CORS_ORIGINS: List[str] = os.getenv("CORS_ORIGINS", "http://localhost:3000,http://127.0.0.1:3000").split(",")
 
+    class Config:
+        """
+        Prefix for automatically parsing environment variables by pydantic. E.g. when an attribute is named
+        `SQE_BACKEND_SERVER_HOST` pydantic tries to parse it automatically from the environment if set.
+        """
+        env_prefix = "SQE_BACKEND_"
+
 
 settings = Settings()

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
 from app.api.api_v1.api import api_router
 from app.db.init_db import init_db
@@ -7,6 +8,13 @@ from app.db.init_db import init_db
 app = FastAPI(
     title=settings.PROJECT_NAME, openapi_url=f"{settings.API_V1_STR}/openapi.json")
 
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.CORS_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
 app.include_router(api_router, prefix=settings.API_V1_STR)
 
 


### PR DESCRIPTION
* Adds `CORSMiddleware`
* Origins can be configured as environment variables: `CORS_ORIGINS={origin},{origin},...,{origin}`. Proper default is set
* Docker still has CORS problems, as the frontend is not defined in our docker compose. No idea how to fix that. Worst case solution is to set cors origins to `*` for the compose. But I would like to avoid that.
* All headers and HTTP verbs allowed currently