### PR TITLE
Return robots with type

### DIFF
--- a/src/app/schemas/robot.py
+++ b/src/app/schemas/robot.py
@@ -1,6 +1,8 @@
 from typing import Optional
 from pydantic import BaseModel
 
+from app.schemas.robot_type import RobotTypeBase
+
 
 class RobotBase(BaseModel):
     id: int
@@ -23,6 +25,16 @@ class RobotCreate(RobotBase):
 class RobotUpdate(RobotBase):
     id: Optional[int]
     robot_type_id: Optional[int]
+
+
+class RobotWithType(RobotBase):
+    robot_type: RobotTypeBase
+
+    @staticmethod
+    def factory(robot: RobotBase, robot_type: RobotTypeBase):
+        dict_obj = robot.as_dict()
+        dict_obj["robot_type"] = robot_type.as_dict()
+        return RobotWithType(**dict_obj)
 
 
 # Properties shared by models stored in DB

--- a/src/app/tests/api/v1/test_robot.py
+++ b/src/app/tests/api/v1/test_robot.py
@@ -41,6 +41,7 @@ async def test_read_robot(client: AsyncClient, database: AsyncSession):
     assert content["id"] == robot_obj.id
     assert content["description"] == robot_obj.description
     assert content["robot_type_id"] == robot_obj.robot_type_id
+    assert content["robot_type"] == robot_type_obj.as_dict()
 
 
 async def test_read_robot_not_found(client: AsyncClient):


### PR DESCRIPTION
* New DTO class `RobotWithType`
* GET Endpoints return robot with the data of its type directly
* Did not implement this for the other endpoints. Was not sure with create, if we need it, It's easy to add there as well
* Endpoint test extended to check the type as well