### PR TITLE
Return project with data

### DIFF
--- a/src/app/api/api_v1/endpoints/project.py
+++ b/src/app/api/api_v1/endpoints/project.py
@@ -39,7 +39,7 @@ async def read_project(
 
 
 @router.post("/upload", response_description="Upload file to create a new project",
-             response_model=Project)
+             response_model=ProjectWithData)
 async def upload_project(
         *,
         db: AsyncSession = Depends(deps.get_async_db),
@@ -66,12 +66,12 @@ async def upload_project(
         raise HTTPException(status_code=500, detail="Could not create new project")
 
     # Create welding points
-    result = await welding_point.create_multi(
+    welding_points = await welding_point.create_multi(
         db=db, obj_in=parser.get_welding_points(project=project_obj))
-    if result is None:
-        raise HTTPException(status_code=500, detail="Could not create welding point")
+    if welding_points is None:
+        raise HTTPException(status_code=500, detail="Could not create welding points")
 
-    return project_obj
+    return ProjectWithData.factory(project_obj, welding_points)
 
 
 @router.post("/", response_description="Add new project", response_model=Project)

--- a/src/app/api/api_v1/endpoints/project.py
+++ b/src/app/api/api_v1/endpoints/project.py
@@ -44,6 +44,7 @@ async def upload_project(
         *,
         db: AsyncSession = Depends(deps.get_async_db),
         name: str,
+        description: Optional[str] = None,
         file: UploadFile
 ) -> Any:
     """
@@ -59,7 +60,7 @@ async def upload_project(
         raise HTTPException(status_code=415, detail=parse_result.detail)
 
     # Create new project
-    project_create = ProjectCreate(name=name)
+    project_create = ProjectCreate(name=name, description=description)
     project_obj = await project.create(db=db, obj_in=project_create)
     if project_obj is None:
         raise HTTPException(status_code=500, detail="Could not create new project")

--- a/src/app/schemas/project.py
+++ b/src/app/schemas/project.py
@@ -1,6 +1,8 @@
-from typing import Optional
+from typing import Optional, List
 from pydantic import BaseModel
 from pydantic.schema import datetime
+
+from app.schemas.welding_point import WeldingPointBase
 
 
 class ProjectBase(BaseModel):
@@ -24,6 +26,16 @@ class ProjectCreate(ProjectBase):
 class ProjectUpdate(ProjectBase):
     id: Optional[int]
     name: Optional[str]
+
+
+class ProjectWithData(ProjectBase):
+    welding_points: List[WeldingPointBase]
+
+    @staticmethod
+    def factory(project: ProjectBase, welding_points: List[WeldingPointBase]):
+        dict_obj = project.as_dict()
+        dict_obj["welding_points"] = [obj.as_dict() for obj in welding_points]
+        return ProjectWithData(**dict_obj)
 
 
 # Properties shared by models stored in DB

--- a/src/app/tests/api/v1/test_project.py
+++ b/src/app/tests/api/v1/test_project.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.tests.utils.models import create_project
 from app.crud.crud_project import project
+from app.schemas.welding_point import WeldingPoint
 from testdata.getter import get_file
 from testdata.validation import validate_project_file_welding_points
 
@@ -91,6 +92,9 @@ async def test_upload_project(client: AsyncClient, database: AsyncSession):
     content = response.json()
     assert "id" in content
     assert content["name"] == "testproject"
+
+    welding_points = [WeldingPoint(**obj) for obj in content["welding_points"]]
+    validate_project_file_welding_points(welding_points)
 
     project_obj = await project.get_by_id(db=database, id=content["id"])
     validate_project_file_welding_points(project_obj.welding_points)


### PR DESCRIPTION
* Project upload can now also set description (I would allow this in the UI as well. We have enough space there)
* New DTO class `ProjectWithData` for returning a project with its welding points
* Used in the file upload endpoint as discussed ~2 weeks ago
* Test for endpoint checks the response welding points as well