### PR TITLE
CRUD update bugfix and catching integrity errors

### DIFF
--- a/src/app/api/api_v1/endpoints/robot_type.py
+++ b/src/app/api/api_v1/endpoints/robot_type.py
@@ -80,6 +80,8 @@ async def delete_robot_type(
     robot_type_obj = await robot_type.get_by_id(db=db, id=robot_type_id)
     if not robot_type_obj:
         raise HTTPException(status_code=404, detail="Robot type not found")
+    if len(robot_type_obj.robots) > 0:
+        raise HTTPException(status_code=420, detail="Robot type has existing robots. Please delete first")
 
     result = await robot_type.remove(db=db, obj=robot_type_obj)
     await db.commit()

--- a/src/app/crud/base.py
+++ b/src/app/crud/base.py
@@ -68,7 +68,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
             db_obj: ModelType,
             obj_in: Union[UpdateSchemaType, Dict[str, Any]]
     ) -> ModelType:
-        obj_data = jsonable_encoder(db_obj)
+        obj_data = db_obj.as_dict()
         update_data = obj_in if isinstance(obj_in, dict) else obj_in.dict(exclude_unset=True)
         for field in obj_data:
             if field in update_data:

--- a/src/app/tests/crud/test_crud_generation_template.py
+++ b/src/app/tests/crud/test_crud_generation_template.py
@@ -28,10 +28,11 @@ async def test_crud_generation_template_get_multi(database: AsyncSession):
 
 
 async def test_crud_generation_template_update(database: AsyncSession):
-    generation_template_obj = await create_generation_template(db=database)
+    generation_template_obj = await create_generation_template(db=database, commit_and_refresh=True)
     await generation_template.update(db=database, db_obj=generation_template_obj, obj_in={"name": "modified"})
     assert generation_template_obj.name == "modified"
 
+    await database.refresh(generation_template_obj)
     await generation_template.update(db=database, db_obj=generation_template_obj,
                                      obj_in=GenerationTemplateUpdate(name="modified again"))
     assert generation_template_obj.name == "modified again"

--- a/src/app/tests/crud/test_crud_project.py
+++ b/src/app/tests/crud/test_crud_project.py
@@ -28,10 +28,11 @@ async def test_crud_project_get_multi(database: AsyncSession):
 
 
 async def test_crud_project_update(database: AsyncSession):
-    project_obj = await create_project(db=database)
+    project_obj = await create_project(db=database, commit_and_refresh=True)
     await project.update(db=database, db_obj=project_obj, obj_in={"name": "modified"})
     assert project_obj.name == "modified"
 
+    await database.refresh(project_obj)
     await project.update(db=database, db_obj=project_obj, obj_in=ProjectUpdate(name="modified again"))
     assert project_obj.name == "modified again"
 


### PR DESCRIPTION
Fixes a bug in the CRUD update: When an object had a valid relationship object present, we run into recursion error. The issue was, once again, `jsonable_encoder`. 
`jsonable_encoder` always runs into an endless loop with some(?) relationships: E.g. traversing`Project → Robot → Project → Robot → Project ...` when converting an object into a dictionary. I first thought the issue is when relationships don't have a back population defined for the other entity of the relationship  (would have made sense to have a configured "oh, I don't need to traverse here anymore" condition) ...but did not turn out true. 

Replaced it now with the `as_dict` function as well. A one-liner function working like charm. Maybe it is a workaround, and we will find the true issue some day...but at least it works now. And it is basically doing the exact same thing for us. I still suspect this is a bug in FastAPI.

The problem could be triggered easily via frontend:
* Assign robot to welding point
* Try to unassign it again

→ Was not possible until now. It failed due to the presence of the robot object in the welding point.

---
Also added some integrity errors catching for entities without cascade delete in the backend enabled:
* GenerationTemplate
* Robot
* Robot Type 