### PR TITLE
Codegen improvements

### DIFF
--- a/src/app/codegen/code_generator.py
+++ b/src/app/codegen/code_generator.py
@@ -55,7 +55,7 @@ class CodeGenerator:
 
         # Robot for which the program will be generated
         robots = set([wp.robot.id for wp in welding_points])
-        if len(robots) !== 1 or robots[0] is None:
+        if len(robots) != 1 or robots[0] is None:
             raise CodeGeneratorException("All welding points must have the same non-None robot")
         robot = welding_points[0].robot
 

--- a/src/app/codegen/code_generator.py
+++ b/src/app/codegen/code_generator.py
@@ -54,9 +54,10 @@ class CodeGenerator:
         func_dict = {"generate_blockly_block_id": TemplateFunctions.generate_blockly_block_id}
 
         # Robot for which the program will be generated
+        robots = set([wp.robot.id for wp in welding_points])
+        if len(robots) !== 1 or robots[0] is None:
+            raise CodeGeneratorException("All welding points must have the same non-None robot")
         robot = welding_points[0].robot
-        if robot is None:
-            raise CodeGeneratorException("Welding point does not have a robot")
 
         # Add welding points x, y, z relative to robot to be available as expression in templates
         wp_list = [wp.as_dict() for wp in welding_points]

--- a/src/app/codegen/code_generator.py
+++ b/src/app/codegen/code_generator.py
@@ -109,7 +109,7 @@ class CodeGenerator:
 
         # Write generated code to file
         for generated in generated_code:
-            filename = (f"{generated.robot.id}_{generated.robot.name}"
+            filename = (f"{generated.robot.name}"
                         f".{generated.robot.robot_type.generation_template.file_extension}")
             in_memory_zip.writestr(filename, generated.code)
         in_memory_zip.close()

--- a/src/app/codegen/code_generator.py
+++ b/src/app/codegen/code_generator.py
@@ -36,6 +36,10 @@ class TemplateFunctions:
         return "".join(random.choices(string.ascii_letters + string.digits, k=20))
 
 
+class CodeGeneratorException(Exception):
+    pass
+
+
 class CodeGenerator:
     @staticmethod
     def generate(template: GenerationTemplate, welding_points: List[WeldingPoint]) -> str:
@@ -51,6 +55,8 @@ class CodeGenerator:
 
         # Robot for which the program will be generated
         robot = welding_points[0].robot
+        if robot is None:
+            raise CodeGeneratorException("Welding point does not have a robot")
 
         # Add welding points x, y, z relative to robot to be available as expression in templates
         wp_list = [wp.as_dict() for wp in welding_points]

--- a/src/app/codegen/code_generator.py
+++ b/src/app/codegen/code_generator.py
@@ -49,13 +49,23 @@ class CodeGenerator:
         # Define a dictionary with functions, which can be used in templates
         func_dict = {"generate_blockly_block_id": TemplateFunctions.generate_blockly_block_id}
 
+        # Robot for which the program will be generated
+        robot = welding_points[0].robot
+
+        # Add welding points x, y, z relative to robot to be available as expression in templates
+        wp_list = [wp.as_dict() for wp in welding_points]
+        for wp in wp_list:
+            wp["x_rel"] = wp["x"] - robot.position_x
+            wp["y_rel"] = wp["y"] - robot.position_y
+            wp["z_rel"] = wp["z"] - robot.position_z
+
         # Create new jinja environment and load template from string
         env = Environment(loader=BaseLoader(),
                           keep_trailing_newline=True,
                           autoescape=True,
                           undefined=jinja2.StrictUndefined)\
             .from_string(template.content)
-        generated_code = env.render({"welding_points": welding_points} | func_dict)
+        generated_code = env.render({"welding_points": wp_list} | {"robot": robot} | func_dict)
 
         return generated_code
 

--- a/src/app/codegen/code_generator.py
+++ b/src/app/codegen/code_generator.py
@@ -55,7 +55,7 @@ class CodeGenerator:
 
         # Robot for which the program will be generated
         robots = set([wp.robot.id for wp in welding_points])
-        if len(robots) != 1 or robots[0] is None:
+        if len(robots) != 1 or robots.pop() is None:
             raise CodeGeneratorException("All welding points must have the same non-None robot")
         robot = welding_points[0].robot
 

--- a/src/app/tests/codegen/test_codegen_class.py
+++ b/src/app/tests/codegen/test_codegen_class.py
@@ -1,12 +1,21 @@
 from app.codegen.code_generator import CodeGenerator
 from app.models.generation_template import GenerationTemplate
 from app.models.welding_point import WeldingPoint
+from app.models.robot import Robot
 from app.tests.utils.utils import get_example_template
 
 
 def test_code_generation():
+    robot_obj = Robot(id=1,
+                      name="Test Robot",
+                      position_x=1,
+                      position_y=1,
+                      position_z=1)
+
     welding_point_obj = WeldingPoint(project_id=1,
                                      welding_order=0,
+                                     robot_id=robot_obj.id,
+                                     robot=robot_obj,
                                      x=10,
                                      y=5.5,
                                      z=0.25,


### PR DESCRIPTION
* Generated code of robots does not have the ID anymore in the filename. The ID is always hidden for the user, it has no meaning for them in the filename
* Make `x_rel`, `y_rel`, `z_rel` available as additional expressions in templates. It is the relative position of the welding point to the robot 