### PR TITLE
make assignment of project optional for robot on creation

### DIFF
--- a/src/app/models/project.py
+++ b/src/app/models/project.py
@@ -12,5 +12,3 @@ class Project(Base):
     modified_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
     welding_points = relationship("WeldingPoint", back_populates="project", lazy='subquery',
                                   cascade="all, delete")
-    robots = relationship("Robot", back_populates="project", lazy="subquery",
-                          cascade="all, delete")

--- a/src/app/models/robot.py
+++ b/src/app/models/robot.py
@@ -16,4 +16,3 @@ class Robot(Base):
     position_norm_vector_y = Column(Float)
     position_norm_vector_z = Column(Float)
     robot_type = relationship("RobotType", back_populates="robots", lazy="subquery")
-    project = relationship("Project", back_populates="robots", lazy="subquery")

--- a/src/app/schemas/robot.py
+++ b/src/app/schemas/robot.py
@@ -7,7 +7,6 @@ from app.schemas.robot_type import RobotTypeBase
 class RobotBase(BaseModel):
     id: int
     robot_type_id: int
-    project_id: Optional[int]
     name: str
     description: Optional[str]
     position_x: float
@@ -21,7 +20,6 @@ class RobotBase(BaseModel):
         schema_extra = {
             "example": {
                 "robot_type_id": 1,
-                "project_id": 1,
                 "name": "Scratchy",
                 "description": "Robot with the scratch on arm",
                 "position_x": 0.554,

--- a/src/app/schemas/robot.py
+++ b/src/app/schemas/robot.py
@@ -7,7 +7,7 @@ from app.schemas.robot_type import RobotTypeBase
 class RobotBase(BaseModel):
     id: int
     robot_type_id: int
-    project_id: int
+    project_id: Optional[int]
     name: str
     description: Optional[str]
     position_x: float
@@ -40,7 +40,6 @@ class RobotCreate(RobotBase):
 
 class RobotUpdate(RobotBase):
     id: Optional[int]
-    project_id: Optional[int]
     robot_type_id: Optional[int]
     name: Optional[str]
     description: Optional[str]

--- a/src/app/tests/api/v1/test_robot.py
+++ b/src/app/tests/api/v1/test_robot.py
@@ -54,8 +54,7 @@ async def test_read_robot(client: AsyncClient, database: AsyncSession):
     robot_type_obj = await create_robot_type(db=database)
     project_obj = await create_project(db=database)
 
-    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj, project_obj=project_obj,
-                                   commit_and_refresh=True)
+    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj, commit_and_refresh=True)
 
     response = await client.get(f"{settings.API_V1_STR}/robot/{robot_obj.id}")
     assert response.status_code == 200
@@ -83,8 +82,7 @@ async def test_read_robot_not_found(client: AsyncClient):
 async def test_update_robot(client: AsyncClient, database: AsyncSession):
     robot_type_obj = await create_robot_type(db=database)
     project_obj = await create_project(db=database)
-    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj, project_obj=project_obj,
-                                   commit_and_refresh=True)
+    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj, commit_and_refresh=True)
     await database.commit()
     await database.refresh(robot_obj)
 
@@ -102,9 +100,7 @@ async def test_update_robot(client: AsyncClient, database: AsyncSession):
 
 async def test_delete_robot(client: AsyncClient, database: AsyncSession):
     robot_type_obj = await create_robot_type(db=database)
-    project_obj = await create_project(db=database)
-    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj, project_obj=project_obj,
-                                   commit_and_refresh=True)
+    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj, commit_and_refresh=True)
 
     response_delete = await client.delete(f"{settings.API_V1_STR}/robot/{robot_obj.id}")
     assert response_delete.status_code == 200

--- a/src/app/tests/crud/test_crud_robot.py
+++ b/src/app/tests/crud/test_crud_robot.py
@@ -15,7 +15,7 @@ async def test_crud_robot_create_integrity_fail(database: AsyncSession):
     robot_type_obj = RobotType(id=1, name="Test")
     project_obj = Project(id=1, name="Also Test")
     try:
-        await create_robot(db=database, robot_type_obj=robot_type_obj, project_obj=project_obj)
+        await create_robot(db=database, robot_type_obj=robot_type_obj)
         assert False
     except IntegrityError:
         assert True
@@ -23,8 +23,7 @@ async def test_crud_robot_create_integrity_fail(database: AsyncSession):
 
 async def test_crud_robot_create(database: AsyncSession):
     robot_type_obj = await create_robot_type(db=database)
-    project_obj = await create_project(db=database)
-    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj, project_obj=project_obj)
+    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj)
 
     robot_obj_get = await robot.get(db=database, id=robot_obj.id)
     assert robot_obj.as_dict() == robot_obj_get.as_dict()
@@ -32,8 +31,7 @@ async def test_crud_robot_create(database: AsyncSession):
 
 async def test_crud_robot_get(database: AsyncSession):
     robot_type_obj = await create_robot_type(db=database)
-    project_obj = await create_project(db=database)
-    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj, project_obj=project_obj)
+    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj)
 
     robot_obj_get = await robot.get_by_id(db=database, id=robot_obj.id)
     assert robot_obj.__eq__(robot_obj_get)
@@ -41,10 +39,9 @@ async def test_crud_robot_get(database: AsyncSession):
 
 async def test_crud_robot_get_multi(database: AsyncSession):
     robot_type_obj = await create_robot_type(db=database)
-    project_obj = await create_project(db=database)
 
-    await create_robot(db=database, robot_type_obj=robot_type_obj, project_obj=project_obj)
-    await create_robot(db=database, robot_type_obj=robot_type_obj, project_obj=project_obj)
+    await create_robot(db=database, robot_type_obj=robot_type_obj)
+    await create_robot(db=database, robot_type_obj=robot_type_obj)
 
     robots = await robot.get_multi(db=database)
     assert len(robots) == 2
@@ -52,9 +49,8 @@ async def test_crud_robot_get_multi(database: AsyncSession):
 
 async def test_crud_robot_update(database: AsyncSession):
     robot_type_obj = await create_robot_type(db=database)
-    project_obj = await create_project(db=database)
 
-    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj, project_obj=project_obj)
+    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj)
     await robot.update(db=database, db_obj=robot_obj, obj_in={"description": "modified"})
     assert robot_obj.description == "modified"
 
@@ -64,9 +60,8 @@ async def test_crud_robot_update(database: AsyncSession):
 
 async def test_crud_robot_delete(database: AsyncSession):
     robot_type_obj = await create_robot_type(db=database)
-    project_obj = await create_project(db=database)
 
-    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj, project_obj=project_obj)
+    robot_obj = await create_robot(db=database, robot_type_obj=robot_type_obj)
 
     result = await robot.remove(db=database, obj=robot_obj)
     assert robot_obj.as_dict() == result.as_dict()

--- a/src/app/tests/utils/models.py
+++ b/src/app/tests/utils/models.py
@@ -61,11 +61,10 @@ async def create_robot_type(db: AsyncSession, template_id: Optional[int] = None,
     return robot_type_obj
 
 
-async def create_robot(db: AsyncSession, robot_type_obj: RobotType, project_obj: Project,
+async def create_robot(db: AsyncSession, robot_type_obj: RobotType,
                        commit_and_refresh: bool = False) -> Robot:
     robot_in = RobotCreate(
         robot_type_id=robot_type_obj.id,
-        project_id=project_obj.id,
         name=random_string(),
         description=random_string(),
         position_x=random_float(),


### PR DESCRIPTION
I realized that it didn't make sense to assign a robot to a project without assigning it to a welding point...

The frontend currently disregarded this information.